### PR TITLE
Fix USPS Domain Name

### DIFF
--- a/custom_components/email/parsers/usps.py
+++ b/custom_components/email/parsers/usps.py
@@ -7,7 +7,7 @@ from ..const import EMAIL_ATTR_BODY
 
 _LOGGER = logging.getLogger(__name__)
 ATTR_USPS = 'usps'
-EMAIL_DOMAIN_USPS = 'usps.gov'
+EMAIL_DOMAIN_USPS = 'usps.com'
 
 
 def parse_usps(email):


### PR DESCRIPTION
I'm not sure if the code changed or the Post Office changed their domain name, but the sensor was no longer capturing Postal Service packages.  Changing the TLD from .gov to .com has fixed it in my installation, and I thought I'd share the wealth.