### PR TITLE
Update usps.py

### DIFF
--- a/custom_components/email/parsers/usps.py
+++ b/custom_components/email/parsers/usps.py
@@ -21,5 +21,8 @@ def parse_usps(email):
         match = re.search('selectedTrckNum=(.*?)&selectedTypeOfLabel', link)
         if match and match.group(1) not in tracking_numbers:
             tracking_numbers.append(match.group(1))
+        match = re.search('tLabels=(.*?)&', link)
+        if match and match.group(1) not in tracking_numbers:
+            tracking_numbers.append(match.group(1))
 
     return tracking_numbers


### PR DESCRIPTION
Added 2nd URL string to search for -- adds compatibility with the emails you get from USPS when you track a package and ask for email updates.  Apparently they do not use the same tracking URL for both the Informed Delivery Daily Digest emails and the requested update emails.