### PR TITLE
Added support for Amazon.de emails (in English)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "files.associations": {
+        "*.yaml": "home-assistant"
+    }
+}

--- a/custom_components/email/parsers/amazon_de.py
+++ b/custom_components/email/parsers/amazon_de.py
@@ -1,0 +1,44 @@
+import logging
+import re
+
+from bs4 import BeautifulSoup
+from ..const import EMAIL_ATTR_BODY, EMAIL_ATTR_SUBJECT
+
+
+_LOGGER = logging.getLogger(__name__)
+ATTR_AMAZON_DE = 'amazon_de'
+EMAIL_DOMAIN_AMAZON_DE = 'amazon.de'
+
+def parse_amazon_de(email):
+    """Parse Amazon tracking numbers."""
+    tracking_numbers = []
+ 
+    soup = BeautifulSoup(email[EMAIL_ATTR_BODY], 'html.parser')
+
+    # see if it's an shipped order email
+    order_number_match = re.search('Order: #(.*?)\n', email[EMAIL_ATTR_BODY])
+    if not order_number_match:
+        order_number_match = re.search('Your Amazon.de order of (.*?) has been dispatched!', email[EMAIL_ATTR_SUBJECT])
+    if not order_number_match:
+        return tracking_numbers
+
+    order_number = order_number_match.group(1)
+
+    # find the link that has 'track your package' text
+    linkElements = soup.find_all('a')
+    for linkElement in linkElements:
+        if not re.search(r'track your package', linkElement.text, re.IGNORECASE):
+            continue
+        
+        # if found we no get url and check for duplicates
+        link = linkElement.get('href')
+
+        # make sure we dont have dupes
+        order_numbers = list(map(lambda x: x['tracking_number'], tracking_numbers))
+        if order_number not in order_numbers:
+            tracking_numbers.append({
+                'link': link,
+                'tracking_number': order_number
+            })
+
+    return tracking_numbers

--- a/custom_components/email/sensor.py
+++ b/custom_components/email/sensor.py
@@ -19,6 +19,7 @@ from .const import (
 
 from .parsers.ups import ATTR_UPS, EMAIL_DOMAIN_UPS, parse_ups
 from .parsers.amazon import ATTR_AMAZON, EMAIL_DOMAIN_AMAZON, parse_amazon
+from .parsers.amazon_de import ATTR_AMAZON_DE, EMAIL_DOMAIN_AMAZON_DE, parse_amazon_de
 from .parsers.fedex import ATTR_FEDEX, EMAIL_DOMAIN_FEDEX, parse_fedex
 from .parsers.paypal import ATTR_PAYPAL, EMAIL_DOMAIN_PAYPAL, parse_paypal
 from .parsers.usps import ATTR_USPS, EMAIL_DOMAIN_USPS, parse_usps
@@ -64,6 +65,7 @@ parsers = [
     (ATTR_UPS, EMAIL_DOMAIN_UPS, parse_ups),
     (ATTR_FEDEX, EMAIL_DOMAIN_FEDEX, parse_fedex),
     (ATTR_AMAZON, EMAIL_DOMAIN_AMAZON, parse_amazon),
+    (ATTR_AMAZON_DE, EMAIL_DOMAIN_AMAZON_DE, parse_amazon_de),
     (ATTR_PAYPAL, EMAIL_DOMAIN_PAYPAL, parse_paypal),
     (ATTR_USPS, EMAIL_DOMAIN_USPS, parse_usps),
     (ATTR_ALI_EXPRESS, EMAIL_DOMAIN_ALI_EXPRESS, parse_ali_express),


### PR DESCRIPTION
I've added a parser for Amazon.de for my own use, since it sends different emails than Amazon.com. Maybe it will be helpful for someone else as well. :)
![image](https://user-images.githubusercontent.com/1450852/222853591-68ed0cd4-4c02-4740-a95a-060e58d8f5e1.png)

