### PR TITLE
Fix tracking number parsing of swiss_post.py parser

### DIFF
--- a/custom_components/email/parsers/swiss_post.py
+++ b/custom_components/email/parsers/swiss_post.py
@@ -18,7 +18,7 @@ def parse_swiss_post(email):
     for link in links:
         if not link:
             continue
-        match = re.search('formattedParcelCodes=(.*?)$', link)
+        match = re.search('formattedParcelCodes=(\d+)', link)
         if match and match.group(1) not in tracking_numbers:
             tracking_numbers.append(match.group(1))
 


### PR DESCRIPTION
The current tracking-number parsing includes also the rest of link which leads to unreadable numbers and duplicates. This commit fixes this.